### PR TITLE
Add 'About' section to Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,9 @@
 
 ## About
 
+NVD3 (http://nvd3.org/) is JavaScript library that was built specifically to generate beautiful charts using D3.js (http://d3js.org/), a JavaScript library built to manipulate documents based on data.
 
+This module enables the NVD3 charting code for your own uses, providing you with ever so useful graphs.
 
 ## Contributing
 


### PR DESCRIPTION
The 'about' section of README was empty so I added the one from [PS16 developer documentation](http://doc.prestashop.com/display/PS16/Administration+modules#Administrationmodules-NVD3Charts).