### PR TITLE
Avoid legend items to overlap in stats module

### DIFF
--- a/graphnvd3.php
+++ b/graphnvd3.php
@@ -108,6 +108,7 @@ class GraphNvD3 extends ModuleGraphEngine
 			success: function(jsonData){
 				nv.addGraph(function(){
 					var chart = ' . $nvd3_func[$params['type']] . ';
+					chart.legend.align(false);
 
 					if (jsonData.axisLabels.xAxis != null)
 						chart.xAxis.axisLabel(jsonData.axisLabels.xAxis);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In some languages, when there are two legend items, one can overlap the other if too long.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#29792.
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
